### PR TITLE
webpack config tweaks + add cypress as dev deps

### DIFF
--- a/client/src/store.js
+++ b/client/src/store.js
@@ -1,7 +1,7 @@
 import Epics from './actions/epics'
 import { createStore, applyMiddleware, combineReducers, compose } from 'redux'
 import { createEpicMiddleware } from 'redux-observable'
-import createLogger from 'redux-logger'
+import { createLogger } from 'redux-logger'
 import userReducer from './reducers/userReducer'
 import appListReducer from './reducers/appListReducer'
 import dialogReducer from './reducers/dialogReducer'

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+    "testFiles": "**/*.feature"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,105 @@
                 "@babel/types": "^7.4.4"
             }
         },
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+            "integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-member-expression-to-functions": "^7.5.5",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.5.5",
+                "@babel/helper-split-export-declaration": "^7.4.4"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                    "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.0.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.6.0",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+                    "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.6.0",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-member-expression-to-functions": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+                    "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.5.5"
+                    }
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+                    "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "^7.5.5",
+                        "@babel/helper-optimise-call-expression": "^7.0.0",
+                        "@babel/traverse": "^7.5.5",
+                        "@babel/types": "^7.5.5"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.6.0",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+                    "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+                    "dev": true
+                },
+                "@babel/traverse": {
+                    "version": "7.6.0",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
+                    "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.6.0",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.4",
+                        "@babel/parser": "^7.6.0",
+                        "@babel/types": "^7.6.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.6.1",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+                    "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
         "@babel/helper-define-map": {
             "version": "7.4.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
@@ -282,6 +381,16 @@
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-remap-async-to-generator": "^7.1.0",
                 "@babel/plugin-syntax-async-generators": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.0.tgz",
+            "integrity": "sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.3.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-proposal-json-strings": {
@@ -617,6 +726,18 @@
             "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-runtime": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+            "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.1"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -1033,6 +1154,185 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
                     "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
+                }
+            }
+        },
+        "@cypress/browserify-preprocessor": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-2.1.1.tgz",
+            "integrity": "sha512-S+0bzZbRsiFbrLkEygu5D0958z4ejio7hWxnO5MoSqD7SmZOmGRpjuZ9RaGcDmL6RWnklNjn8DkpP2s368qCKA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "7.4.5",
+                "@babel/plugin-proposal-class-properties": "7.3.0",
+                "@babel/plugin-proposal-object-rest-spread": "7.3.2",
+                "@babel/plugin-transform-runtime": "7.2.0",
+                "@babel/preset-env": "7.4.5",
+                "@babel/preset-react": "7.0.0",
+                "@babel/runtime": "7.3.1",
+                "babel-plugin-add-module-exports": "1.0.0",
+                "babelify": "10.0.0",
+                "bluebird": "3.5.3",
+                "browserify": "16.2.3",
+                "coffeeify": "3.0.1",
+                "coffeescript": "1.12.7",
+                "debug": "4.1.1",
+                "fs-extra": "7.0.1",
+                "lodash.clonedeep": "4.5.0",
+                "watchify": "3.11.1"
+            },
+            "dependencies": {
+                "@babel/plugin-proposal-object-rest-spread": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
+                    "integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+                    }
+                },
+                "@babel/runtime": {
+                    "version": "7.3.1",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+                    "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.12.0"
+                    }
+                },
+                "bluebird": {
+                    "version": "3.5.3",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+                    "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+                    "dev": true
+                },
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "dev": true
+                }
+            }
+        },
+        "@cypress/listr-verbose-renderer": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+            "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "cli-cursor": "^1.0.2",
+                "date-fns": "^1.27.2",
+                "figures": "^1.7.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^1.0.1"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "@cypress/xvfb": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+            "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "lodash.once": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
                 }
             }
         },
@@ -2097,6 +2397,37 @@
             "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
             "dev": true
         },
+        "acorn-node": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+            "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.0.0",
+                "acorn-walk": "^7.0.0",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+                    "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+                    "dev": true
+                },
+                "xtend": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+                    "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-walk": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
+            "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==",
+            "dev": true
+        },
         "ajv": {
             "version": "6.10.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -2175,6 +2506,12 @@
             "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
             "dev": true
         },
+        "any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+            "dev": true
+        },
         "anymatch": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -2198,6 +2535,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+        },
+        "arch": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+            "dev": true
         },
         "are-we-there-yet": {
             "version": "1.1.5",
@@ -2363,6 +2706,31 @@
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true
+        },
+        "assertion-error-formatter": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-2.0.1.tgz",
+            "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
+            "dev": true,
+            "requires": {
+                "diff": "^3.0.0",
+                "pad-right": "^0.2.2",
+                "repeat-string": "^1.6.1"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "dev": true
+                }
+            }
+        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2378,6 +2746,15 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
+        },
+        "async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.10"
+            }
         },
         "async-each": {
             "version": "1.0.3",
@@ -2615,6 +2992,15 @@
                 }
             }
         },
+        "babel-plugin-add-module-exports": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.0.tgz",
+            "integrity": "sha512-m0sMxPL4FaN2K69GQgaRJa4Ny15qKSdoknIcpN+gz+NaJlAW9pge/povs13tPYsKDboflrEQC+/3kfIsONBTaw==",
+            "dev": true,
+            "requires": {
+                "chokidar": "^2.0.4"
+            }
+        },
         "babel-plugin-transform-imports": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.5.1.tgz",
@@ -2666,6 +3052,12 @@
                     "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
                 }
             }
+        },
+        "babelify": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+            "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
+            "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -2734,6 +3126,12 @@
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "becke-ch--regex--s0-0-v1--base--pl--lib": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/becke-ch--regex--s0-0-v1--base--pl--lib/-/becke-ch--regex--s0-0-v1--base--pl--lib-1.4.0.tgz",
+            "integrity": "sha1-Qpzuu/pffpNueNc/vcfacWKyDiA=",
+            "dev": true
         },
         "big.js": {
             "version": "5.2.2",
@@ -2901,6 +3299,179 @@
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
+        "browser-pack": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+            "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "combine-source-map": "~0.8.0",
+                "defined": "^1.0.0",
+                "safe-buffer": "^5.1.1",
+                "through2": "^2.0.0",
+                "umd": "^3.0.0"
+            }
+        },
+        "browser-resolve": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify": {
+            "version": "16.2.3",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.3.tgz",
+            "integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "assert": "^1.4.0",
+                "browser-pack": "^6.0.1",
+                "browser-resolve": "^1.11.0",
+                "browserify-zlib": "~0.2.0",
+                "buffer": "^5.0.2",
+                "cached-path-relative": "^1.0.0",
+                "concat-stream": "^1.6.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "~1.0.0",
+                "crypto-browserify": "^3.0.0",
+                "defined": "^1.0.0",
+                "deps-sort": "^2.0.0",
+                "domain-browser": "^1.2.0",
+                "duplexer2": "~0.1.2",
+                "events": "^2.0.0",
+                "glob": "^7.1.0",
+                "has": "^1.0.0",
+                "htmlescape": "^1.1.0",
+                "https-browserify": "^1.0.0",
+                "inherits": "~2.0.1",
+                "insert-module-globals": "^7.0.0",
+                "labeled-stream-splicer": "^2.0.0",
+                "mkdirp": "^0.5.0",
+                "module-deps": "^6.0.0",
+                "os-browserify": "~0.3.0",
+                "parents": "^1.0.1",
+                "path-browserify": "~0.0.0",
+                "process": "~0.11.0",
+                "punycode": "^1.3.2",
+                "querystring-es3": "~0.2.0",
+                "read-only-stream": "^2.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.1.4",
+                "shasum": "^1.0.0",
+                "shell-quote": "^1.6.1",
+                "stream-browserify": "^2.0.0",
+                "stream-http": "^2.0.0",
+                "string_decoder": "^1.1.1",
+                "subarg": "^1.0.0",
+                "syntax-error": "^1.1.1",
+                "through2": "^2.0.0",
+                "timers-browserify": "^1.0.1",
+                "tty-browserify": "0.0.1",
+                "url": "~0.11.0",
+                "util": "~0.10.1",
+                "vm-browserify": "^1.0.0",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "5.4.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+                    "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4"
+                    }
+                },
+                "events": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+                    "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    },
+                    "dependencies": {
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "timers-browserify": {
+                    "version": "1.4.2",
+                    "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+                    "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+                    "dev": true,
+                    "requires": {
+                        "process": "~0.11.0"
+                    }
+                },
+                "tty-browserify": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+                    "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+                    "dev": true
+                },
+                "url": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+                    "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "1.3.2",
+                        "querystring": "0.2.0"
+                    }
+                },
+                "util": {
+                    "version": "0.10.4",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+                    "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    },
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
         "browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -2985,6 +3556,12 @@
                 "ieee754": "^1.1.4",
                 "isarray": "^1.0.0"
             }
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
         },
         "buffer-equal-constant-time": {
             "version": "1.0.1",
@@ -3093,6 +3670,21 @@
                     "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
                     "dev": true
                 }
+            }
+        },
+        "cached-path-relative": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+            "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+            "dev": true
+        },
+        "cachedir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.3.0.tgz",
+            "integrity": "sha512-O1ji32oyON9laVPJL1IZ5bmwd2cB46VfpxkDequezH+15FDzzVddEyrGEeX4WusDSqKxdyFdDQDEG1yo1GoWkg==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.1"
             }
         },
         "call-me-maybe": {
@@ -3213,6 +3805,20 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+            "dev": true,
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
         "chain-function": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
@@ -3237,6 +3843,18 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
+        },
+        "check-more-types": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+            "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
             "dev": true
         },
         "chokidar": {
@@ -3380,6 +3998,29 @@
                 "restore-cursor": "^2.0.0"
             }
         },
+        "cli-spinners": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+            "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+            "dev": true
+        },
+        "cli-table": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+            "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+            "dev": true,
+            "requires": {
+                "colors": "1.0.3"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+                    "dev": true
+                }
+            }
+        },
         "cli-truncate": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -3497,6 +4138,22 @@
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
+        "coffeeify": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-3.0.1.tgz",
+            "integrity": "sha512-Qjnr7UX6ldK1PHV7wCnv7AuCd4q19KTUtwJnu/6JRJB4rfm12zvcXtKdacUoePOKr1I4ka/ydKiwWpNAdsQb0g==",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "^1.3.0",
+                "through2": "^2.0.0"
+            }
+        },
+        "coffeescript": {
+            "version": "1.12.7",
+            "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+            "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+            "dev": true
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3557,6 +4214,38 @@
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
         },
+        "combine-source-map": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "~1.1.0",
+                "inline-source-map": "~0.6.0",
+                "lodash.memoize": "~3.0.3",
+                "source-map": "~0.5.3"
+            },
+            "dependencies": {
+                "convert-source-map": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+                    "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+                    "dev": true
+                },
+                "lodash.memoize": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+                    "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3569,6 +4258,12 @@
             "version": "2.20.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
             "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        },
+        "common-tags": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -4111,6 +4806,74 @@
                 }
             }
         },
+        "cucumber": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-4.2.1.tgz",
+            "integrity": "sha512-3gQ0Vv4kSHsvXEFC6b1c+TfLRDzWD1/kU7e5vm8Kh8j35b95k6favan9/4ixcBNqd7UsU1T6FYcawC87+DlNKw==",
+            "dev": true,
+            "requires": {
+                "assertion-error-formatter": "^2.0.1",
+                "babel-runtime": "^6.11.6",
+                "bluebird": "^3.4.1",
+                "cli-table": "^0.3.1",
+                "colors": "^1.1.2",
+                "commander": "^2.9.0",
+                "cucumber-expressions": "^5.0.13",
+                "cucumber-tag-expressions": "^1.1.1",
+                "duration": "^0.2.0",
+                "escape-string-regexp": "^1.0.5",
+                "figures": "2.0.0",
+                "gherkin": "^5.0.0",
+                "glob": "^7.0.0",
+                "indent-string": "^3.1.0",
+                "is-generator": "^1.0.2",
+                "is-stream": "^1.1.0",
+                "knuth-shuffle-seeded": "^1.0.6",
+                "lodash": "^4.17.4",
+                "mz": "^2.4.0",
+                "progress": "^2.0.0",
+                "resolve": "^1.3.3",
+                "serialize-error": "^2.1.0",
+                "stack-chain": "^2.0.0",
+                "stacktrace-js": "^2.0.0",
+                "string-argv": "0.0.2",
+                "title-case": "^2.1.1",
+                "util-arity": "^1.0.2",
+                "verror": "^1.9.0"
+            },
+            "dependencies": {
+                "cucumber-expressions": {
+                    "version": "5.0.18",
+                    "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-5.0.18.tgz",
+                    "integrity": "sha1-bHB3nv0668Xp54U5OLERAyJClZY=",
+                    "dev": true,
+                    "requires": {
+                        "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.2.0"
+                    }
+                },
+                "string-argv": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+                    "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+                    "dev": true
+                }
+            }
+        },
+        "cucumber-expressions": {
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-6.6.2.tgz",
+            "integrity": "sha512-WcFSVBiWNLJbIcAAC3t/ACU46vaOKfe1UIF5H3qveoq+Y4XQm9j3YwHurQNufRKBBg8nCnpU7Ttsx7egjS3hwA==",
+            "dev": true,
+            "requires": {
+                "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.2.0"
+            }
+        },
+        "cucumber-tag-expressions": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cucumber-tag-expressions/-/cucumber-tag-expressions-1.1.1.tgz",
+            "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo=",
+            "dev": true
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4124,6 +4887,448 @@
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
             "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
         },
+        "cypress": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
+            "integrity": "sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==",
+            "dev": true,
+            "requires": {
+                "@cypress/listr-verbose-renderer": "0.4.1",
+                "@cypress/xvfb": "1.2.4",
+                "arch": "2.1.1",
+                "bluebird": "3.5.0",
+                "cachedir": "1.3.0",
+                "chalk": "2.4.2",
+                "check-more-types": "2.24.0",
+                "commander": "2.15.1",
+                "common-tags": "1.8.0",
+                "debug": "3.2.6",
+                "execa": "0.10.0",
+                "executable": "4.1.1",
+                "extract-zip": "1.6.7",
+                "fs-extra": "5.0.0",
+                "getos": "3.1.1",
+                "is-ci": "1.2.1",
+                "is-installed-globally": "0.1.0",
+                "lazy-ass": "1.6.0",
+                "listr": "0.12.0",
+                "lodash": "4.17.15",
+                "log-symbols": "2.2.0",
+                "minimist": "1.2.0",
+                "moment": "2.24.0",
+                "ramda": "0.24.1",
+                "request": "2.88.0",
+                "request-progress": "3.0.0",
+                "supports-color": "5.5.0",
+                "tmp": "0.1.0",
+                "url": "0.11.0",
+                "yauzl": "2.10.0"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+                    "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "bluebird": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+                    "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+                    "dev": true
+                },
+                "ci-info": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+                    "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+                    "dev": true
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^1.0.1"
+                    }
+                },
+                "commander": {
+                    "version": "2.15.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "execa": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+                    "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
+                    }
+                },
+                "fs-extra": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "indent-string": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                    "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                    "dev": true,
+                    "requires": {
+                        "repeating": "^2.0.0"
+                    }
+                },
+                "is-ci": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+                    "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^1.5.0"
+                    }
+                },
+                "listr": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
+                    "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.1.3",
+                        "cli-truncate": "^0.2.1",
+                        "figures": "^1.7.0",
+                        "indent-string": "^2.1.0",
+                        "is-promise": "^2.1.0",
+                        "is-stream": "^1.1.0",
+                        "listr-silent-renderer": "^1.1.1",
+                        "listr-update-renderer": "^0.2.0",
+                        "listr-verbose-renderer": "^0.4.0",
+                        "log-symbols": "^1.0.2",
+                        "log-update": "^1.0.2",
+                        "ora": "^0.2.3",
+                        "p-map": "^1.1.1",
+                        "rxjs": "^5.0.0-beta.11",
+                        "stream-to-observable": "^0.1.0",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^2.2.1",
+                                "escape-string-regexp": "^1.0.2",
+                                "has-ansi": "^2.0.0",
+                                "strip-ansi": "^3.0.0",
+                                "supports-color": "^2.0.0"
+                            }
+                        },
+                        "log-symbols": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+                            "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^1.0.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "listr-update-renderer": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
+                    "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.1.3",
+                        "cli-truncate": "^0.2.1",
+                        "elegant-spinner": "^1.0.1",
+                        "figures": "^1.7.0",
+                        "indent-string": "^3.0.0",
+                        "log-symbols": "^1.0.2",
+                        "log-update": "^1.0.2",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^2.2.1",
+                                "escape-string-regexp": "^1.0.2",
+                                "has-ansi": "^2.0.0",
+                                "strip-ansi": "^3.0.0",
+                                "supports-color": "^2.0.0"
+                            }
+                        },
+                        "indent-string": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                            "dev": true
+                        },
+                        "log-symbols": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+                            "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                            "dev": true,
+                            "requires": {
+                                "chalk": "^1.0.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "listr-verbose-renderer": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+                    "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.1.3",
+                        "cli-cursor": "^1.0.2",
+                        "date-fns": "^1.27.2",
+                        "figures": "^1.7.0"
+                    },
+                    "dependencies": {
+                        "chalk": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^2.2.1",
+                                "escape-string-regexp": "^1.0.2",
+                                "has-ansi": "^2.0.0",
+                                "strip-ansi": "^3.0.0",
+                                "supports-color": "^2.0.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "log-symbols": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+                    "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1"
+                    }
+                },
+                "log-update": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+                    "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^1.0.0",
+                        "cli-cursor": "^1.0.2"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "p-map": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+                    "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
+                    }
+                },
+                "rxjs": {
+                    "version": "5.5.12",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+                    "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+                    "dev": true,
+                    "requires": {
+                        "symbol-observable": "1.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "symbol-observable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+                    "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+                    "dev": true
+                },
+                "tmp": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+                    "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+                    "dev": true,
+                    "requires": {
+                        "rimraf": "^2.6.3"
+                    }
+                },
+                "url": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+                    "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "1.3.2",
+                        "querystring": "0.2.0"
+                    }
+                }
+            }
+        },
+        "cypress-cucumber-preprocessor": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-1.16.0.tgz",
+            "integrity": "sha512-U3V15iMEKkb7qIePEn22QyDcOjsT+/HRTS6cdKBB2BgtYBCnkWZJ1jfUhf3rFDMMoXFkExSNZG/i00ljF/DUkA==",
+            "dev": true,
+            "requires": {
+                "@cypress/browserify-preprocessor": "^2.1.1",
+                "chai": "^4.1.2",
+                "chokidar": "^2.0.4",
+                "cosmiconfig": "^4.0.0",
+                "cucumber": "^4.2.1",
+                "cucumber-expressions": "^6.0.1",
+                "cucumber-tag-expressions": "^1.1.1",
+                "debug": "^3.0.1",
+                "gherkin": "^5.1.0",
+                "glob": "^7.1.2",
+                "through": "^2.3.8"
+            },
+            "dependencies": {
+                "cosmiconfig": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+                    "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^4.0.0",
+                        "require-from-string": "^2.0.1"
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "dargs": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -4132,6 +5337,12 @@
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
+        },
+        "dash-ast": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+            "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+            "dev": true
         },
         "dashdash": {
             "version": "1.14.1",
@@ -4212,6 +5423,15 @@
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
             "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "^4.0.0"
+            }
         },
         "deep-extend": {
             "version": "0.6.0",
@@ -4344,6 +5564,18 @@
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
+        "deps-sort": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+            "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "shasum": "^1.0.0",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0"
+            }
+        },
         "des.js": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -4363,6 +5595,25 @@
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
             "dev": true
+        },
+        "detective": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+            "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.6.1",
+                "defined": "^1.0.0",
+                "minimist": "^1.1.1"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
         },
         "diff": {
             "version": "4.0.1",
@@ -4463,6 +5714,41 @@
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
             "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
         },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -4502,6 +5788,16 @@
                         "safe-buffer": "~5.1.0"
                     }
                 }
+            }
+        },
+        "duration": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+            "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.46"
             }
         },
         "easy-table": {
@@ -4618,6 +5914,15 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "error-stack-parser": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.4.tgz",
+            "integrity": "sha512-fZ0KkoxSjLFmhW5lHbUT3tLwy3nX1qEzMYo8koY1vrsAco53CMT1djnBSeC/wUjTEZRhZl9iRw7PaMaxfJ4wzQ==",
+            "dev": true,
+            "requires": {
+                "stackframe": "^1.1.0"
+            }
+        },
         "es-abstract": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
@@ -4641,15 +5946,47 @@
                 "is-symbol": "^1.0.2"
             }
         },
+        "es5-ext": {
+            "version": "0.10.51",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+            "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "^1.0.0"
+            }
+        },
         "es6-error": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
             "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
         },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "es6-promise-polyfill": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
             "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4="
+        },
+        "es6-symbol": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+            "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.51"
+            }
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -4859,6 +6196,29 @@
                 "strip-eof": "^1.0.0"
             }
         },
+        "executable": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+            "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+            "dev": true,
+            "requires": {
+                "pify": "^2.2.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
         "expand-brackets": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -5006,6 +6366,44 @@
                 }
             }
         },
+        "extract-zip": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1",
+                "yauzl": "2.4.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "yauzl": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+                    "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+                    "dev": true,
+                    "requires": {
+                        "fd-slicer": "~1.0.1"
+                    }
+                }
+            }
+        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -5069,6 +6467,15 @@
                     "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
                     "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
                 }
+            }
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true,
+            "requires": {
+                "pend": "~1.2.0"
             }
         },
         "figgy-pudding": {
@@ -5443,11 +6850,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -5460,15 +6869,18 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -5571,7 +6983,8 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -5581,6 +6994,7 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -5593,17 +7007,20 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -5620,6 +7037,7 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5692,7 +7110,8 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5702,6 +7121,7 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -5807,6 +7227,7 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5948,10 +7369,22 @@
                 "globule": "^1.0.0"
             }
         },
+        "get-assigned-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+            "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+            "dev": true
+        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
         "get-own-enumerable-property-symbols": {
@@ -5981,6 +7414,15 @@
             "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.4.tgz",
             "integrity": "sha512-Rz7DGyomZjrenu9Jx4qmzdlvJgvrEFHXHvjK0FcZtcTC1U5FmES7OdZHUwMuSnEE6QvBvwse1JODKj7TgbSEjQ=="
         },
+        "getos": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.1.tgz",
+            "integrity": "sha512-oUP1rnEhAr97rkitiszGP9EgDVYnmchgFzfqRzSkgtfv7ai6tEi7Ko8GgjNXts7VLWEqrTWyhsOKLe5C5b/Zkg==",
+            "dev": true,
+            "requires": {
+                "async": "2.6.1"
+            }
+        },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -5988,6 +7430,12 @@
             "requires": {
                 "assert-plus": "^1.0.0"
             }
+        },
+        "gherkin": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.1.0.tgz",
+            "integrity": "sha1-aEu7A63STq9731RPWAM+so+zxtU=",
+            "dev": true
         },
         "git-raw-commits": {
             "version": "1.3.6",
@@ -6743,6 +8191,12 @@
                 }
             }
         },
+        "htmlescape": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+            "dev": true
+        },
         "htmlparser2": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -7103,6 +8557,23 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
+        "inline-source-map": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.5.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
         "inline-style-prefixer": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
@@ -7154,6 +8625,24 @@
                         }
                     }
                 }
+            }
+        },
+        "insert-module-globals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+            "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "acorn-node": "^1.5.2",
+                "combine-source-map": "^0.8.0",
+                "concat-stream": "^1.6.1",
+                "is-buffer": "^1.1.0",
+                "path-is-absolute": "^1.0.1",
+                "process": "~0.11.0",
+                "through2": "^2.0.0",
+                "undeclared-identifiers": "^1.1.2",
+                "xtend": "^4.0.0"
             }
         },
         "interpret": {
@@ -7307,6 +8796,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "is-generator": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+            "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
+            "dev": true
         },
         "is-glob": {
             "version": "4.0.1",
@@ -7470,9 +8965,9 @@
             }
         },
         "is-retry-allowed": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
             "dev": true
         },
         "is-stream": {
@@ -7899,6 +9394,15 @@
                 }
             }
         },
+        "knuth-shuffle-seeded": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/knuth-shuffle-seeded/-/knuth-shuffle-seeded-1.0.6.tgz",
+            "integrity": "sha1-AfG2VzOqdUDuCNiwF0Fk0iCB5OE=",
+            "dev": true,
+            "requires": {
+                "seed-random": "~2.2.0"
+            }
+        },
         "lab": {
             "version": "18.0.2",
             "resolved": "https://registry.npmjs.org/lab/-/lab-18.0.2.tgz",
@@ -7941,6 +9445,16 @@
                 }
             }
         },
+        "labeled-stream-splicer": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+            "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "stream-splicer": "^2.0.0"
+            }
+        },
         "latest-version": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -7949,6 +9463,12 @@
             "requires": {
                 "package-json": "^6.3.0"
             }
+        },
+        "lazy-ass": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+            "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+            "dev": true
         },
         "lcid": {
             "version": "2.0.0",
@@ -8322,6 +9842,12 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
         },
         "lodash.findkey": {
             "version": "4.6.0",
@@ -8960,6 +10486,61 @@
                 "semver": "^5.3.0"
             }
         },
+        "module-deps": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.1.tgz",
+            "integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "browser-resolve": "^1.7.0",
+                "cached-path-relative": "^1.0.2",
+                "concat-stream": "~1.6.0",
+                "defined": "^1.0.0",
+                "detective": "^5.0.2",
+                "duplexer2": "^0.1.2",
+                "inherits": "^2.0.1",
+                "parents": "^1.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.4.0",
+                "stream-combiner2": "^1.1.1",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+            "dev": true
+        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -8988,6 +10569,17 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
+        },
+        "mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "requires": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
         },
         "nan": {
             "version": "2.14.0",
@@ -9050,6 +10642,12 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
             "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
         },
         "nice-try": {
             "version": "1.0.5",
@@ -9449,9 +11047,9 @@
             }
         },
         "nodemon": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.1.tgz",
-            "integrity": "sha512-/DXLzd/GhiaDXXbGId5BzxP1GlsqtMGM9zTmkWrgXtSqjKmGSbLicM/oAy4FR0YWm14jCHRwnR31AHS2dYFHrg==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.2.tgz",
+            "integrity": "sha512-hRLYaw5Ihyw9zK7NF+9EUzVyS6Cvgc14yh8CAYr38tPxJa6UrOxwAQ351GwrgoanHCF0FalQFn6w5eoX/LGdJw==",
             "dev": true,
             "requires": {
                 "chokidar": "^2.1.5",
@@ -9906,6 +11504,85 @@
                 }
             }
         },
+        "ora": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+            "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.1",
+                "cli-cursor": "^1.0.2",
+                "cli-spinners": "^0.1.2",
+                "object-assign": "^4.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^1.0.1"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
         "os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -9978,6 +11655,15 @@
             "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
+            }
+        },
+        "outpipe": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+            "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
+            "dev": true,
+            "requires": {
+                "shell-quote": "^1.4.2"
             }
         },
         "p-cancelable": {
@@ -10059,6 +11745,15 @@
             "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
             "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
         },
+        "pad-right": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+            "dev": true,
+            "requires": {
+                "repeat-string": "^1.5.2"
+            }
+        },
         "pako": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -10113,6 +11808,15 @@
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
+            }
+        },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "~0.11.15"
             }
         },
         "parse-asn1": {
@@ -10200,6 +11904,12 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
         "path-root": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
@@ -10236,6 +11946,12 @@
                 "pify": "^3.0.0"
             }
         },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
         "pbkdf2": {
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -10247,6 +11963,12 @@
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
             }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
         },
         "performance-now": {
             "version": "2.1.0",
@@ -11078,6 +12800,12 @@
             "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
             "dev": true
         },
+        "ramda": {
+            "version": "0.24.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+            "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
+            "dev": true
+        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11356,6 +13084,41 @@
                 "loose-envify": "^1.4.0",
                 "prop-types": "^15.6.2",
                 "react-lifecycles-compat": "^3.0.4"
+            }
+        },
+        "read-only-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "read-pkg": {
@@ -11745,10 +13508,25 @@
                 "uuid": "^3.3.2"
             }
         },
+        "request-progress": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+            "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+            "dev": true,
+            "requires": {
+                "throttleit": "^1.0.0"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true
         },
         "require-main-filename": {
             "version": "2.0.0",
@@ -12167,6 +13945,12 @@
                 }
             }
         },
+        "seed-random": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+            "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=",
+            "dev": true
+        },
         "seedrandom": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
@@ -12192,6 +13976,12 @@
             "requires": {
                 "semver": "^5.0.3"
             }
+        },
+        "serialize-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+            "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+            "dev": true
         },
         "serialize-javascript": {
             "version": "1.7.0",
@@ -12255,6 +14045,27 @@
                 }
             }
         },
+        "shasum": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "~0.0.0",
+                "sha.js": "~2.4.4"
+            },
+            "dependencies": {
+                "json-stable-stringify": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                    "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+                    "dev": true,
+                    "requires": {
+                        "jsonify": "~0.0.0"
+                    }
+                }
+            }
+        },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -12270,6 +14081,12 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
+        "shell-quote": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+            "dev": true
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -12279,6 +14096,12 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
             "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
+        },
+        "simple-concat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+            "dev": true
         },
         "slash": {
             "version": "1.0.0",
@@ -12565,6 +14388,56 @@
                 "figgy-pudding": "^3.5.1"
             }
         },
+        "stack-chain": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
+            "integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg==",
+            "dev": true
+        },
+        "stack-generator": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.4.tgz",
+            "integrity": "sha512-ha1gosTNcgxwzo9uKTQ8zZ49aUp5FIUW58YHFxCqaAHtE0XqBg0chGFYA1MfmW//x1KWq3F4G7Ug7bJh4RiRtg==",
+            "dev": true,
+            "requires": {
+                "stackframe": "^1.1.0"
+            }
+        },
+        "stackframe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.0.tgz",
+            "integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg==",
+            "dev": true
+        },
+        "stacktrace-gps": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.3.tgz",
+            "integrity": "sha512-51Rr7dXkyFUKNmhY/vqZWK+EvdsfFSRiQVtgHTFlAdNIYaDD7bVh21yBHXaNWAvTD+w+QSjxHg7/v6Tz4veExA==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.6",
+                "stackframe": "^1.1.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                    "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                    "dev": true
+                }
+            }
+        },
+        "stacktrace-js": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.1.tgz",
+            "integrity": "sha512-13oDNgBSeWtdGa4/2BycNyKqe+VktCoJ8VLx4pDoJkwGGJVtiHdfMOAj3aW9xTi8oR2v34z9IcvfCvT6XNdNAw==",
+            "dev": true,
+            "requires": {
+                "error-stack-parser": "^2.0.4",
+                "stack-generator": "^2.0.4",
+                "stacktrace-gps": "^3.0.3"
+            }
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -12649,6 +14522,42 @@
                 }
             }
         },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
         "stream-each": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -12698,6 +14607,48 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+        },
+        "stream-splicer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+            "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "stream-to-observable": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
+            "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
+            "dev": true
         },
         "strict-uri-encode": {
             "version": "1.1.0",
@@ -12798,6 +14749,23 @@
             "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
             "requires": {
                 "loader-utils": "^1.0.2"
+            }
+        },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.1.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
             }
         },
         "superagent": {
@@ -12931,6 +14899,15 @@
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
             "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
         },
+        "syntax-error": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+            "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.2.0"
+            }
+        },
         "tabbable": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-1.1.3.tgz",
@@ -13029,6 +15006,30 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "thenify": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+            "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+            "dev": true,
+            "requires": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+            "dev": true,
+            "requires": {
+                "thenify": ">= 3.1.0 < 4"
+            }
+        },
+        "throttleit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+            "dev": true
+        },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -13098,6 +15099,16 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
             "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
+        },
+        "title-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+            "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+            "dev": true,
+            "requires": {
+                "no-case": "^2.2.0",
+                "upper-case": "^1.0.3"
+            }
         },
         "tmp": {
             "version": "0.0.33",
@@ -13265,6 +15276,12 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
         "type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -13273,6 +15290,12 @@
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
         },
         "type-fest": {
             "version": "0.3.1",
@@ -13300,10 +15323,29 @@
                 "source-map": "~0.6.1"
             }
         },
+        "umd": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+            "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+            "dev": true
+        },
         "unc-path-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+        },
+        "undeclared-identifiers": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+            "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.3.0",
+                "dash-ast": "^1.0.0",
+                "get-assigned-identifiers": "^1.2.0",
+                "simple-concat": "^1.0.0",
+                "xtend": "^4.0.1"
+            }
         },
         "undefsafe": {
             "version": "2.0.2",
@@ -13547,6 +15589,12 @@
                 }
             }
         },
+        "util-arity": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
+            "integrity": "sha1-WdAa8f2z/t4KxOYysKtfbOl8kzA=",
+            "dev": true
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13641,6 +15689,21 @@
             "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
             "requires": {
                 "loose-envify": "^1.0.0"
+            }
+        },
+        "watchify": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.1.tgz",
+            "integrity": "sha512-WwnUClyFNRMB2NIiHgJU9RQPQNqVeFk7OmZaWf5dC5EnNa0Mgr7imBydbaJ7tGTuPM2hz1Cb4uiBvK9NVxMfog==",
+            "dev": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "browserify": "^16.1.0",
+                "chokidar": "^2.1.1",
+                "defined": "^1.0.0",
+                "outpipe": "^1.1.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "watchpack": {
@@ -14033,6 +16096,27 @@
             "requires": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
+            }
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            },
+            "dependencies": {
+                "fd-slicer": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+                    "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+                    "dev": true,
+                    "requires": {
+                        "pend": "~1.2.0"
+                    }
+                }
             }
         },
         "z-schema": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "webpack -p --config ./webpack.config.js",
         "start": "NODE_ENV=production node ./src/main.js",
-        "dev": "DEBUG=knex:tx NODE_ENV=development nodemon --inspect src/main.js",
+        "dev": "DEBUG=knex:tx NODE_ENV=development DEBUG='appstore*' nodemon --watch ./src --watch ./client/ --inspect src/main.js",
         "test": "NODE_ENV=test npm run reset-and-seed-db && lab -a code -t 80 -v -I 'core,__core-js_shared__' test/index.js",
         "test-coverage": "NODE_ENV=test lab -c -a code -r html -o coverage/coverage.html test/index.js",
         "reset-db": "npx knex migrate:rollback && npx knex migrate:latest",
@@ -82,7 +82,7 @@
         "eslint-plugin-hapi": "^4.1.0",
         "lab": "^18.0.2",
         "mock-knex": "^0.4.4",
-        "nodemon": "^1.18.10",
+        "nodemon": "^1.19.2",
         "sqlite3": "^4.0.6",
         "webpack-cli": "^3.3.5"
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "test-coverage": "NODE_ENV=test lab -c -a code -r html -o coverage/coverage.html test/index.js",
         "reset-db": "npx knex migrate:rollback && npx knex migrate:latest",
         "seed-db": "npx knex seed:run",
-        "reset-and-seed-db": "npx knex migrate:rollback && npx knex migrate:latest && npx knex seed:run"
+        "reset-and-seed-db": "npx knex migrate:rollback && npx knex migrate:latest && npx knex seed:run",
+        "cypress:open": "cypress open"
     },
     "dependencies": {
         "@babel/core": "^7.4.5",
@@ -78,6 +79,8 @@
     "devDependencies": {
         "@dhis2/cli-style": "^4.1.1",
         "code": "^5.2.4",
+        "cypress": "^3.4.1",
+        "cypress-cucumber-preprocessor": "^1.16.0",
         "eslint-config-hapi": "^12.0.0",
         "eslint-plugin-hapi": "^4.1.0",
         "lab": "^18.0.2",
@@ -85,5 +88,8 @@
         "nodemon": "^1.19.2",
         "sqlite3": "^4.0.6",
         "webpack-cli": "^3.3.5"
+    },
+    "cypress-cucumber-preprocessor": {
+        "nonGlobalStepDefinitions": true
     }
 }

--- a/src/security/index.js
+++ b/src/security/index.js
@@ -77,7 +77,10 @@ const currentUserIsManager = (request, hapi) =>
  * Returns the current auth strategy, for example 'jwt' if using auth0, false if no strategy
  */
 const getCurrentAuthStrategy = () => {
-    if (process.env.AUTH_STRATEGY !== undefined) {
+    if (
+        process.env.AUTH_STRATEGY !== undefined &&
+        process.env.AUTH_STRATEGY !== ''
+    ) {
         return process.env.AUTH_STRATEGY
     }
 
@@ -88,7 +91,10 @@ const getCurrentAuthStrategy = () => {
  * Returns the auth strategy config in optional mode
  */
 const getCurrentAuthStrategyOptional = () => {
-    if (process.env.AUTH_STRATEGY === 'jwt') {
+    if (
+        process.env.AUTH_STRATEGY === 'jwt' &&
+        process.env.AUTH_STRATEGY !== ''
+    ) {
         return {
             strategy: process.env.AUTH_STRATEGY,
             mode: 'try',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,16 +5,16 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const nodeEnv = process.env.NODE_ENV || 'development'
 
-const isDevBuild = process.argv.indexOf('-p') === -1
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false'
 const config = require('./config/configResolver.js').default
 
 const appEntry = path.join(__dirname, 'client/src/app-store.js')
 
-const prod = {
+const webpackConfig = {
     entry: {
         app: ['whatwg-fetch', appEntry],
     },
+    mode: nodeEnv,
     output: {
         path: path.join(__dirname, 'static'),
         filename: path.join('js', `[name]_${packageJSON.version}.js`),
@@ -63,18 +63,16 @@ const prod = {
     plugins: [
         new webpack.DefinePlugin({
             'process.env': {
-                NODE_ENV: JSON.stringify('production'),
+                NODE_ENV: JSON.stringify(nodeEnv),
             },
             __APP_CONFIG__: JSON.stringify(config),
         }),
-        new webpack.optimize.ModuleConcatenationPlugin(),
         new CopyWebpackPlugin([
             {
                 from: path.join(__dirname, 'client/src/assets'),
                 to: 'assets',
             },
         ]),
-
         new HtmlWebpackPlugin({
             title: 'DHIS2 Appstore',
             filename: 'index.html',
@@ -83,42 +81,4 @@ const prod = {
     ],
 }
 
-const dev = Object.assign({}, prod, {
-    entry: {
-        app: ['whatwg-fetch', appEntry],
-    },
-    output: {
-        path: path.join(__dirname, 'static'),
-        filename: '[name].js',
-        publicPath: '/',
-    },
-
-    devServer: {
-        port: 9000,
-        inline: true,
-        contentBase: './app',
-        historyApiFallback: true,
-    },
-    devtool: 'eval',
-    plugins: [
-        new CopyWebpackPlugin([
-            {
-                from: path.join(__dirname, 'src/assets'),
-                to: 'assets',
-            },
-        ]),
-        new HtmlWebpackPlugin({
-            title: 'DHIS2 Appstore',
-            filename: 'index.html',
-            template: 'indexbuild.html',
-        }),
-        new webpack.DefinePlugin({
-            'process.env': {
-                NODE_ENV: JSON.stringify('development'),
-            },
-            __APP_CONFIG__: JSON.stringify(config),
-        }),
-    ],
-})
-
-module.exports = process.env.NODE_ENV === 'development' ? dev : prod
+module.exports = webpackConfig


### PR DESCRIPTION
fixes so 'npm run dev' works again after FE compilation was moved to internal startup with the node backend.

Also adds some upgrades to package-lock.json and add cypress as dev-deps for the upcoming tests