### PR TITLE
fix: save logo caption and description when uploading app

### DIFF
--- a/seeds/06_media.js
+++ b/seeds/06_media.js
@@ -17,6 +17,8 @@ exports.seed = async knex => {
                 image_type: ImageType.Logo,
                 media_type_id: 2,
                 created_by_user_id: version.created_by_user_id,
+                caption: 'Logo',
+                description: 'A really cool logo',
             },
             {
                 app_version_id: version.id,
@@ -25,6 +27,8 @@ exports.seed = async knex => {
                 image_type: ImageType.Screenshot,
                 media_type_id: 1,
                 created_by_user_id: version.created_by_user_id,
+                caption: 'A Screenshot',
+                description: 'A screenshot of the app',
             },
         ]
     })

--- a/src/data/addAppVersionMedia.js
+++ b/src/data/addAppVersionMedia.js
@@ -26,6 +26,8 @@ const paramSchema = joi
             .string()
             .required()
             .max(255),
+        caption: joi.string().allow(['', null]),
+        description: joi.string().allow(['', null]),
     })
     .options({ allowUnknown: true })
 
@@ -96,6 +98,8 @@ const addAppVersionMedia = async (params, knex, transaction) => {
             created_by_user_id: userId,
             media_type_id: mediaTypeId,
             app_version_id: appVersionId,
+            caption: params.caption,
+            description: params.description,
         }
 
         const [id] = await knex('app_version_media')

--- a/src/data/addAppVersionMedia.js
+++ b/src/data/addAppVersionMedia.js
@@ -46,8 +46,8 @@ const paramSchema = joi
  * @param {number} params.imageType ImageType enum that determines if this is a logotype or image/screenshot
  * @param {string} params.fileName Original filename as when uploaded
  * @param {string} params.mime MIME type for the file, for example 'image/jpeg'
- * @param {string} caption.mime caption/title of the media
- * @param {string} description.mime description of the media
+ * @param {string} params.caption caption/title of the media
+ * @param {string} params.description description of the media
  * @param {object} knex DB instance of knex
  * @returns {Promise<AppVersionMediaResult>}
  */

--- a/src/data/addAppVersionMedia.js
+++ b/src/data/addAppVersionMedia.js
@@ -26,8 +26,8 @@ const paramSchema = joi
             .string()
             .required()
             .max(255),
-        caption: joi.string().allow(['', null]),
-        description: joi.string().allow(['', null]),
+        caption: joi.string().allow('', null),
+        description: joi.string().allow('', null),
     })
     .options({ allowUnknown: true })
 
@@ -46,6 +46,8 @@ const paramSchema = joi
  * @param {number} params.imageType ImageType enum that determines if this is a logotype or image/screenshot
  * @param {string} params.fileName Original filename as when uploaded
  * @param {string} params.mime MIME type for the file, for example 'image/jpeg'
+ * @param {string} caption.mime caption/title of the media
+ * @param {string} description.mime description of the media
  * @param {object} knex DB instance of knex
  * @returns {Promise<AppVersionMediaResult>}
  */

--- a/src/data/addAppVersionMedia.js
+++ b/src/data/addAppVersionMedia.js
@@ -60,7 +60,15 @@ const addAppVersionMedia = async (params, knex, transaction) => {
         throw new Error('No transaction passed to function')
     }
 
-    const { appVersionId, userId, imageType, fileName, mime } = params
+    const {
+        appVersionId,
+        userId,
+        imageType,
+        fileName,
+        mime,
+        caption,
+        description,
+    } = params
     let insertData = null
 
     try {
@@ -98,8 +106,8 @@ const addAppVersionMedia = async (params, knex, transaction) => {
             created_by_user_id: userId,
             media_type_id: mediaTypeId,
             app_version_id: appVersionId,
-            caption: params.caption,
-            description: params.description,
+            caption: caption,
+            description: description,
         }
 
         const [id] = await knex('app_version_media')

--- a/src/models/v1/in/CreateAppModel.js
+++ b/src/models/v1/in/CreateAppModel.js
@@ -24,7 +24,12 @@ const CreateModelAppData = Joi.object().keys({
             channel: Joi.string(),
         })
     ),
-    images: Joi.array(),
+    images: Joi.array().items(
+        Joi.object({
+            caption: Joi.string().allow('', null),
+            description: Joi.string().allow('', null),
+        })
+    ),
 })
 
 const payloadSchema = Joi.object({

--- a/src/routes/v1/apps/handlers/createApp.js
+++ b/src/routes/v1/apps/handlers/createApp.js
@@ -224,7 +224,11 @@ module.exports = {
                     'Inserting logo metadata to db and link it to the appVersion'
                 )
                 const imageFileMetadata = imageFile.hapi
-
+                const [imageInfo] = appJsonPayload.images
+                let caption, description
+                if (imageInfo) {
+                    ;({ caption, description } = imageInfo)
+                }
                 const { id, uuid } = await addAppVersionMedia(
                     {
                         userId: requestUserId,
@@ -232,6 +236,8 @@ module.exports = {
                         imageType: ImageType.Logo,
                         fileName: imageFileMetadata.filename,
                         mime: imageFileMetadata.headers['content-type'],
+                        caption: caption,
+                        description: description,
                     },
                     knex,
                     trx

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -34,7 +34,7 @@ describe('@data::addAppVersionMedia', () => {
         }
         const trx = await db.transaction()
         const { id, uuid } = await addAppVersionMedia(appMedia, db, trx)
-        trx.commit()
+        await trx.commit()
         expect(id)
             .to.be.number()
             .min(1)

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -5,12 +5,13 @@ const { lab } = require('../index')
 const knexConfig = require('../../knexfile')
 const db = require('knex')(knexConfig)
 
-const { it, describe } = lab
-
+const { it, describe, beforeEach, afterEach } = lab
+const { ImageType } = require('../../src/enums')
 const {
     addAppVersionMedia,
     getAppsByUuid,
     createApp,
+    getAppById,
 } = require('../../src/data')
 
 describe('@data::addAppVersionMedia', () => {
@@ -19,6 +20,34 @@ describe('@data::addAppVersionMedia', () => {
             Error,
             'ValidationError: "appVersionId" is required'
         )
+    })
+
+    it('should add appmedia successfully', async () => {
+        const appMedia = {
+            appVersionId: 1, //DHIS2 app
+            userId: 1, //travis user
+            imageType: ImageType.Screenshot,
+            fileName: 'screenshot.jpg',
+            mime: 'image/jpeg',
+            caption: 'Test caption',
+            description: 'a description',
+        }
+        const trx = await db.transaction()
+        const { id, uuid } = await addAppVersionMedia(appMedia, db, trx)
+        trx.commit()
+        expect(id)
+            .to.be.number()
+            .min(1)
+        expect(uuid.length).to.be.equal(36)
+
+        const appWithVersion = await getAppById(1, 'en', db)
+        const mediaApp = appWithVersion.find(
+            a => a.version_id === 1 && a.media_id === id
+        )
+        expect(mediaApp).to.not.be.null()
+
+        expect(mediaApp.media_caption).to.be.equal(appMedia.caption)
+        expect(mediaApp.media_description).to.be.equal(appMedia.description)
     })
 })
 


### PR DESCRIPTION
Currently the information about the image uploaded together with the app was ignored. This adds support to add caption and description when creating a new app.