### PR TITLE
feat: don't wait for app to compile before api-init

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,12 +16,12 @@ process.on('unhandledRejection', err => {
     process.exit(1)
 })
 
-compile()
-    .catch(err => {
-        debug('The web app failed to compile.\n', err)
-        process.exit(1)
-    })
-    .then(() => migrate(knex))
+compile().catch(err => {
+    debug('The web app failed to compile.\n', err)
+    process.exit(1)
+})
+
+migrate(knex)
     .catch(err => {
         debug('The database migrations failed to apply.\n', err)
         process.exit(1)


### PR DESCRIPTION
Small quality of life change. Start API-server immediatly instead of waiting for app-compilation.

Worst case is that you get 404-error if the compilation is not finished yet.