### PR TITLE
fix: contentype to json

### DIFF
--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -16,6 +16,9 @@ const deleteOpts = {
 
 const updateOpts = {
     method: 'PUT',
+    headers: {
+        'content-type': 'application/json',
+    },
 }
 
 export function getAllApps() {
@@ -87,7 +90,7 @@ export function deleteImage(appId, imageId) {
 export function updateApp(appId, payload) {
     return fromApi('apps/' + appId, true, {
         ...baseOptions,
-        method: 'PUT',
+        ...updateOpts,
         body: JSON.stringify(payload),
     })
 }

--- a/src/routes/v1/apps/handlers/editImage.js
+++ b/src/routes/v1/apps/handlers/editImage.js
@@ -36,7 +36,7 @@ module.exports = {
 
         const { mediaUuid, appUuid } = request.params
 
-        const jsonPayload = JSON.parse(request.payload)
+        const jsonPayload = request.payload
 
         const currentUser = await getCurrentUserFromRequest(request, db)
         const appDeveloperId = await getAppDeveloperId(

--- a/src/server/init-server.js
+++ b/src/server/init-server.js
@@ -26,6 +26,9 @@ exports.init = async knex => {
                 headers: ['Accept', 'Content-Type', 'authorization'],
                 additionalHeaders: ['X-Requested-With'],
             },
+            payload: {
+                allow: 'application/json',
+            },
         },
     })
 


### PR DESCRIPTION
After upgrading hapi, something about how it handles `content-type` has changed, resulting in PUT-requests failing since they were sending the JSON as `text/plain`. The error was due to sending a JSON-stringified object to Joi-validation. Before it seems that hapi would be able to parse this into `request.payload` automatically, but not always? It's weird, as some endpoints (`/editAppVersions`, `/editApp`) did not need to parse the payload, but `/editImage` did? ~~I don't really understand why. Any ideas @erikarenhill ?~~

Either way I feel that it's a good thing that the error was caught, as it shouldn't really have worked before.

**EDIT**: I figured out why: `joi@16` is no longer automatically converting strings to object or arrays, see "Array and object string coercion" in the release notes: https://github.com/hapijs/joi/issues/2037.
 `/editImage` was not using joi-validation so that is why we needed to parse the input. 