### PR TITLE
test: make sure swagger endpoints respond with http status 200

### DIFF
--- a/test/routes/index.js
+++ b/test/routes/index.js
@@ -140,10 +140,19 @@ describe('Test that swagger endpoints work', () => {
         await server.stop()
     })
 
-    it('should return 200 on /swagger.json', async () => {
+    it('should return status 200 when requesting /swagger.json', async () => {
         const response = await server.inject({
             method: 'GET',
             url: '/swagger.json',
+        })
+
+        expect(response.statusCode).to.equal(200)
+    })
+
+    it('should return status 200 when requesting /documentation', async () => {
+        const response = await server.inject({
+            method: 'GET',
+            url: '/documentation',
         })
 
         expect(response.statusCode).to.equal(200)

--- a/test/routes/index.js
+++ b/test/routes/index.js
@@ -129,3 +129,23 @@ describe('Make sure the unversioned api fallback to v1', () => {
         )
     })
 })
+
+describe('Test that swagger endpoints work', () => {
+    let server
+    beforeEach(async () => {
+        server = await init(db)
+    })
+
+    afterEach(async () => {
+        await server.stop()
+    })
+
+    it('should return 200 on /swagger.json', async () => {
+        const response = await server.inject({
+            method: 'GET',
+            url: '/swagger.json',
+        })
+
+        expect(response.statusCode).to.equal(200)
+    })
+})


### PR DESCRIPTION
Since we broke swagger docs/generation without noticing, I just added simple smoke tests for this. (swagger.json still returns http 500 but at least now we know and get the status with builds...)