### PR TITLE
ci(codebuild): create artifact containing the built app and server src

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,24 +1,31 @@
 version: 0.2
 
 env:
-  variables:
-    NODE_ENV: "development"
+    variables:
+        NODE_ENV: "development"
 
 phases:
-  install:
-    runtime-versions:
-      nodejs: 10
+    install:
+        runtime-versions:
+            nodejs: 10
 
-  pre_build:
-    commands:
-      - echo Installing NPM dependencies
-      - npm install
+    pre_build:
+        commands:
+            - echo Installing NPM dependencies
+            - npm install
 
-  build:
-    commands:
-      - echo Entered build phase
-      - npm run build
+    build:
+        commands:
+            - echo Entered build phase
+            - npm run build
 
-  post_build:
-    commands:
-      - echo Build completed on $(date)
+    post_build:
+        commands:
+            - echo "Remove files we do not want to deploy"
+            - rm -rf node_modules .git
+            - echo Build completed on $(date)
+
+artifacts:
+    files:
+        - '**/*'
+    name: app-bazaar-$(date +%Y-%m-%d)


### PR DESCRIPTION
Idea is to build the client app in the build pipeline, and then pack it with the source (we need to ignore node_modules for now so removing it before creating the archive).

This will be passed on to the EBS deploy, which will run `npm install` to get the runtime deps needed for the server, and then start everything up.

First step to see if this works is to add the `USE_PREBUILT_APP` environment variable to our staging environments.

If everything works and it stops "broken" deploys, then we can remove the internal compilation mechanism completely.