### PR TITLE
fix: make backend use correct urls behind proxy

### DIFF
--- a/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
+++ b/src/routes/v1/apps/formatting/convertAppsToApiV1Format.js
@@ -1,7 +1,9 @@
 const debug = require('debug')(
     'appstore:server:routes:v1:apps:formatting:convertAppsToApiV1Format'
 )
-const path = require('path')
+
+const getServerUrl = require('../../../../utils/getServerUrl')
+
 const { ImageType } = require('../../../../enums')
 
 const convertDbAppViewRowToAppApiV1Object = app => ({
@@ -70,7 +72,7 @@ const convertAll = (apps, request) => {
         throw new Error('Missing parameter: request')
     }
 
-    const serverUrl = `${request.server.info.protocol}://${request.info.host}/api`
+    const serverUrl = getServerUrl(request)
 
     debug(`Using serverUrl: ${serverUrl}`)
 

--- a/src/utils/getServerUrl.js
+++ b/src/utils/getServerUrl.js
@@ -1,0 +1,23 @@
+/***
+ * Returns the server url for the backend itself based on the request. If we're running behind a proxy, try to fetch the forwarded protocol
+ * @param {object} request incoming hapijs request
+ */
+const getServerUrl = request => {
+    const protocol =
+        request.headers['x-forwarded-proto'] || request.server.info.protocol
+    const host = request.headers['x-forwarded-host'] || request.info.hostname
+    const port = request.headers['x-forwarded-port'] || request.server.info.port
+
+    let portToUseInUrl = ''
+    if (
+        port &&
+        ((protocol === 'https' && port !== 443) ||
+            (protocol == 'http' && port !== 80))
+    ) {
+        portToUseInUrl = `:${port}`
+    }
+
+    return `${protocol}://${host}${portToUseInUrl}/api`
+}
+
+module.exports = getServerUrl

--- a/src/utils/getServerUrl.js
+++ b/src/utils/getServerUrl.js
@@ -6,13 +6,19 @@ const getServerUrl = request => {
     const protocol =
         request.headers['x-forwarded-proto'] || request.server.info.protocol
     const host = request.headers['x-forwarded-host'] || request.info.hostname
-    const port = request.headers['x-forwarded-port'] || request.server.info.port
+
+    //port is of type string from headers but an integer from request.server.info.port
+    const port = +(
+        request.headers['x-forwarded-port'] || request.server.info.port
+    )
 
     let portToUseInUrl = ''
+
+    //only add port to the url if it differs from the protocol standard port 80 vs 443 to get prettier urls
     if (
-        port &&
+        !isNaN(port) &&
         ((protocol === 'https' && port !== 443) ||
-            (protocol == 'http' && port !== 80))
+            (protocol === 'http' && port !== 80))
     ) {
         portToUseInUrl = `:${port}`
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,5 @@
+const getServerUrl = require('./getServerUrl')
+
 function flatten(arr, result = []) {
     for (let i = 0, length = arr.length; i < length; i++) {
         const value = arr[i]
@@ -28,4 +30,5 @@ module.exports = {
     getFile,
     deleteFile,
     deleteDir,
+    getServerUrl,
 }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -185,7 +185,7 @@ describe('utils::getServerUrl', () => {
             },
             headers: {
                 'x-forwarded-proto': 'https',
-                'x-forwarded-port': 1234,
+                'x-forwarded-port': '1234',
             },
         }
 
@@ -207,7 +207,7 @@ describe('utils::getServerUrl', () => {
             },
             headers: {
                 'x-forwarded-proto': 'https',
-                'x-forwarded-port': 1234,
+                'x-forwarded-port': '1234',
                 'x-forwarded-host': 'foobar.com',
             },
         }


### PR DESCRIPTION
Since the nginx reverse proxy in AWS EBS in front of our hapijs/nodejs backend does ssl termination the backend will return http-links even when doing requests over https. To resolve this we pick up the forwarded protocol, port and hostname if available.

According to this docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html the headers is added by default, otherwise we can override the nginx config with a custom ebextension/nginx/nginx.conf file.
