### PR TITLE
chore: move semver from devdeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16396,8 +16396,7 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "semver-compare": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
         "uuid": "^3.3.2",
         "webpack": "^4.41.2",
         "webpack-dev-server": "^3.8.2",
-        "whatwg-fetch": "^2.0.3"
+        "whatwg-fetch": "^2.0.3",
+        "semver": "^6.3.0"
     },
     "devDependencies": {
         "@babel/register": "^7.6.2",
@@ -100,7 +101,6 @@
         "mock-knex": "^0.4.4",
         "mock-local-storage": "^1.1.8",
         "nodemon": "^1.19.2",
-        "semver": "^6.3.0",
         "sinon": "^7.5.0",
         "sinon-chai": "^3.3.0",
         "sqlite3": "^4.0.6",


### PR DESCRIPTION
deploy fails since semver was in devdeps, moved to normal dependency list