### PR TITLE
feat: load channels from backend

### DIFF
--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -175,6 +175,7 @@ export function createUploadVersionOptions(data) {
         minDhisVersion: version.minDhisVersion || null,
         maxDhisVersion: version.maxDhisVersion || null,
         demoUrl: version.demoUrl || null,
+        channel: version.channel,
     }
     const dataFile = data.file
     const form = new FormData()

--- a/client/src/components/appCards/AppCards.jsx
+++ b/client/src/components/appCards/AppCards.jsx
@@ -92,7 +92,7 @@ class AppCards extends Component {
         debug('appcard render with channels', this.props.channels)
         debug('appChannelFilter', this.props.appChannelFilter)
 
-        const channelFilters = this.props.channels.channels.map(c => ({
+        const channelFilters = this.props.channels.list.map(c => ({
             label: c.name,
             toggled: c.name === 'Stable',
             value: c.name,

--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -141,7 +141,7 @@ class VersionListEdit extends Component {
         this.setState({
             editedValues: merge(editedValues, {
                 [versionId]: {
-                    channel: this.props.channels.channels[selectedIndex].name,
+                    channel: this.props.channels.list[selectedIndex].name,
                 },
             }),
         })
@@ -187,15 +187,13 @@ class VersionListEdit extends Component {
             </IconButton>
         )
 
-        const DHISReleaseChannels = this.props.channels.channels.map(
-            channel => (
-                <MenuItem
-                    key={'channel_' + channel.name}
-                    value={channel.name}
-                    primaryText={channel.name}
-                />
-            )
-        )
+        const DHISReleaseChannels = this.props.channels.list.map(channel => (
+            <MenuItem
+                key={'channel_' + channel.name}
+                value={channel.name}
+                primaryText={channel.name}
+            />
+        ))
 
         const editingIcons = [submitIcon, cancelIcon]
         const normalIcons = [editIcon, deleteIcon]

--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -202,6 +202,7 @@ class VersionListEdit extends Component {
 
         const values = merge(version, this.state.editedValues[version.id])
 
+        //TODO: add error instead of passing false to ErrorOrLoading
         return (
             <TableRow key={version.id}>
                 <TableRowColumn style={styles.firstColumn}>
@@ -290,7 +291,10 @@ class VersionListEdit extends Component {
                             {DHISReleaseChannels}
                         </SelectField>
                     ) : edit && this.props.channels.loading ? (
-                        <ErrorOrLoading loading={this.props.channels.loading} />
+                        <ErrorOrLoading
+                            loading={this.props.channels.loading}
+                            error={false}
+                        />
                     ) : (
                         version.channel
                     )}

--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -141,7 +141,7 @@ class VersionListEdit extends Component {
         this.setState({
             editedValues: merge(editedValues, {
                 [versionId]: {
-                    channel: this.props.channels.channels[selectedIndex],
+                    channel: this.props.channels.channels[selectedIndex].name,
                 },
             }),
         })
@@ -190,9 +190,9 @@ class VersionListEdit extends Component {
         const DHISReleaseChannels = this.props.channels.channels.map(
             (channel, i) => (
                 <MenuItem
-                    key={'channel_' + channel}
-                    value={channel}
-                    primaryText={channel}
+                    key={'channel_' + channel.name}
+                    value={channel.name}
+                    primaryText={channel.name}
                 />
             )
         )

--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -188,7 +188,7 @@ class VersionListEdit extends Component {
         )
 
         const DHISReleaseChannels = this.props.channels.channels.map(
-            (channel, i) => (
+            channel => (
                 <MenuItem
                     key={'channel_' + channel.name}
                     value={channel.name}

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -11,6 +11,8 @@ import { loadChannels } from '../../actions/actionCreators'
 
 import ErrorOrLoading from '../utils/ErrorOrLoading'
 
+const DHISVersions = config.ui.dhisVersions
+
 const validate = values => {
     const errors = {}
     const requiredFields = ['version', 'file']
@@ -43,6 +45,8 @@ const NewAppVersionForm = props => {
 
     const loading = channels.loading
 
+    const DHISReleaseChannels = channels.channels.map(c => c.name)
+
     return loading ? (
         <ErrorOrLoading loading={loading} />
     ) : (
@@ -72,7 +76,7 @@ const NewAppVersionForm = props => {
                 name="channel"
                 component={formUtils.renderAutoCompleteField}
                 label="Release channel"
-                dataSource={this.props.channels.channels}
+                dataSource={DHISReleaseChannels}
             />
             <Field
                 name="demoUrl"
@@ -96,9 +100,6 @@ const NewAppVersionForm = props => {
 NewAppVersionForm.propTypes = {
     submitted: PropTypes.func.isRequired,
 }
-const ReduxFormComponent = reduxForm({ form: 'newAppVersionForm', validate })(
-    NewAppVersionForm
-)
 
 const mapStateToProps = state => ({
     channels: state.channels,
@@ -110,7 +111,11 @@ const mapDispatchToProps = dispatch => ({
     },
 })
 
-export default connect(
+const ConnectedNewAppVersionForm = connect(
     mapStateToProps,
     mapDispatchToProps
-)(ReduxFormComponent)
+)(NewAppVersionForm)
+
+export default reduxForm({ form: 'newAppVersionForm', validate })(
+    ConnectedNewAppVersionForm
+)

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -47,8 +47,9 @@ const NewAppVersionForm = props => {
 
     const DHISReleaseChannels = channels.channels.map(c => c.name)
 
+    //TODO: add error instead of passing false to ErrorOrLoading
     return loading ? (
-        <ErrorOrLoading loading={loading} />
+        <ErrorOrLoading loading={loading} error={false} />
     ) : (
         <Form onSubmit={handleSubmit(onSub)}>
             <Field

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
 import { Card, CardText } from 'material-ui/Card'
 import * as formUtils from './ReduxFormUtils'
 import MenuItem from 'material-ui/MenuItem'
@@ -6,8 +7,9 @@ import { Field, Form, reduxForm } from 'redux-form'
 import config from '../../../../config'
 import { validateZipFile, validateURL } from './ReduxFormUtils'
 
-const DHISVersions = config.ui.dhisVersions
-const DHISReleaseChannels = config.ui.releaseChannels
+import { loadChannels } from '../../actions/actionCreators'
+
+import ErrorOrLoading from '../utils/ErrorOrLoading'
 
 const validate = values => {
     const errors = {}
@@ -22,7 +24,7 @@ const validate = values => {
 }
 
 const NewAppVersionForm = props => {
-    const { handleSubmit, pristine, submitting, submitFailed } = props
+    const { handleSubmit, pristine, submitting, submitFailed, channels } = props
     //this is called when the form is submitted, translating
     //fields to an object the api understands.
     //we then call props.submitted, so this data can be passed to parent component
@@ -39,7 +41,11 @@ const NewAppVersionForm = props => {
         return props.submitted({ data, file: file })
     }
 
-    return (
+    const loading = channels.loading
+
+    return loading ? (
+        <ErrorOrLoading loading={loading} />
+    ) : (
         <Form onSubmit={handleSubmit(onSub)}>
             <Field
                 name="version"
@@ -66,7 +72,7 @@ const NewAppVersionForm = props => {
                 name="channel"
                 component={formUtils.renderAutoCompleteField}
                 label="Release channel"
-                dataSource={DHISReleaseChannels}
+                dataSource={this.props.channels.channels}
             />
             <Field
                 name="demoUrl"
@@ -90,6 +96,21 @@ const NewAppVersionForm = props => {
 NewAppVersionForm.propTypes = {
     submitted: PropTypes.func.isRequired,
 }
-export default reduxForm({ form: 'newAppVersionForm', validate })(
+const ReduxFormComponent = reduxForm({ form: 'newAppVersionForm', validate })(
     NewAppVersionForm
 )
+
+const mapStateToProps = state => ({
+    channels: state.channels,
+})
+
+const mapDispatchToProps = dispatch => ({
+    loadChannels() {
+        dispatch(loadChannels())
+    },
+})
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ReduxFormComponent)

--- a/client/src/components/form/NewAppVersionForm.jsx
+++ b/client/src/components/form/NewAppVersionForm.jsx
@@ -45,7 +45,7 @@ const NewAppVersionForm = props => {
 
     const loading = channels.loading
 
-    const DHISReleaseChannels = channels.channels.map(c => c.name)
+    const DHISReleaseChannels = channels.list.map(c => c.name)
 
     //TODO: add error instead of passing false to ErrorOrLoading
     return loading ? (

--- a/client/src/components/form/UploadAppFormStepper.jsx
+++ b/client/src/components/form/UploadAppFormStepper.jsx
@@ -346,7 +346,7 @@ class UploadAppFormStepper extends Component {
                     <AppGeneralSection name="general" />,
                     <AppVersionSection
                         name="version"
-                        channels={this.props.channels.channels}
+                        channels={this.props.channels.list}
                     />,
                     <AppDeveloperSection name="developer" />,
                     <AppImageSection name="image" />,

--- a/client/src/components/form/UploadAppFormStepper.jsx
+++ b/client/src/components/form/UploadAppFormStepper.jsx
@@ -334,9 +334,9 @@ class UploadAppFormStepper extends Component {
 
     render() {
         const loading = this.props.channels.loading
-
+        //TODO: add error instead of passing false to ErrorOrLoading
         return loading ? (
-            <ErrorOrLoading loading={loading} />
+            <ErrorOrLoading loading={loading} error={false} />
         ) : (
             <FormStepper
                 form="uploadAppForm"

--- a/client/src/components/form/UploadAppFormStepper.jsx
+++ b/client/src/components/form/UploadAppFormStepper.jsx
@@ -81,10 +81,10 @@ const validate = values => {
     return errors
 }
 
-const appTypesItems = appTypes.map((type, i) => (
+const appTypesItems = appTypes.map(type => (
     <MenuItem key={type.value} value={type.value} primaryText={type.label} />
 ))
-const DHISVersionItems = config.ui.dhisVersions.map((version, i) => (
+const DHISVersionItems = config.ui.dhisVersions.map(version => (
     <MenuItem key={version} value={version} primaryText={version} />
 ))
 
@@ -133,7 +133,7 @@ AppGeneralSection.defaultProps = {
 }
 
 const AppVersionSection = props => {
-    const releaseChannels = props.channels.map((channel, i) => (
+    const releaseChannels = props.channels.map(channel => (
         <MenuItem
             key={channel.name}
             value={channel.name}

--- a/client/src/reducers/channelReducer.js
+++ b/client/src/reducers/channelReducer.js
@@ -3,7 +3,7 @@ import * as actionTypes from '../constants/actionTypes'
 const initialState = {
     loading: false,
     loaded: false,
-    channels: [],
+    list: [],
 }
 
 const channelReducer = (state = initialState, action) => {
@@ -30,7 +30,7 @@ const channelReducer = (state = initialState, action) => {
                 ...state,
                 loading: false,
                 loaded: true,
-                channels: action.payload,
+                list: action.payload,
             }
         }
 

--- a/default.config.js
+++ b/default.config.js
@@ -34,6 +34,5 @@ module.exports = {
             DASHBOARD_WIDGET: 'Dashboard',
             TRACKER_DASHBOARD_WIDGET: 'Tracker Dashboard',
         },
-        releaseChannels: ['Stable', 'Development', 'Canary'],
     },
 }

--- a/development.config.js
+++ b/development.config.js
@@ -34,6 +34,5 @@ module.exports = {
             DASHBOARD_WIDGET: 'Dashboard',
             TRACKER_DASHBOARD_WIDGET: 'Tracker Dashboard',
         },
-        releaseChannels: ['Stable', 'Development', 'Canary'],
     },
 }

--- a/src/data/createAppVersion.js
+++ b/src/data/createAppVersion.js
@@ -8,8 +8,8 @@ const paramsSchema = joi
     .keys({
         userId: joi.number().required(),
         appId: joi.number().required(),
-        demoUrl: joi.string().allow(''),
-        sourceUrl: joi.string().allow(''),
+        demoUrl: joi.string().allow('', null),
+        sourceUrl: joi.string().allow('', null),
         version: joi.string().allow(''),
     })
     .options({ allowUnknown: true })

--- a/src/models/v1/in/CreateAppVersionModel.js
+++ b/src/models/v1/in/CreateAppVersionModel.js
@@ -7,8 +7,8 @@ const Joi = require('@hapi/joi')
 const CreateAppVersionModel = Joi.object().keys({
     version: Joi.string(),
     minDhisVersion: Joi.string(),
-    maxDhisVersion: Joi.string().allow(''),
-    demoUrl: Joi.string().allow(''),
+    maxDhisVersion: Joi.string().allow('', null),
+    demoUrl: Joi.string().allow('', null),
     images: Joi.array(),
     channel: Joi.string(),
 })

--- a/src/routes/v1/apps/handlers/createAppVersion.js
+++ b/src/routes/v1/apps/handlers/createAppVersion.js
@@ -122,13 +122,15 @@ module.exports = {
                 version,
                 minDhisVersion,
                 maxDhisVersion,
+                channel,
             } = appVersionJson
 
             const [dbApp] = dbAppRows
             debug(`Adding version to app ${dbApp.name}`)
+            let appVersion = null
 
             try {
-                const appVersion = await createAppVersion(
+                appVersion = await createAppVersion(
                     {
                         userId: currentUserId,
                         appId: dbApp.app_id,
@@ -163,13 +165,12 @@ module.exports = {
                 throw Boom.internal('Could not save localized appversion', err)
             }
 
-            const publishChannel = 'Stable'
             try {
                 await addAppVersionToChannel(
                     {
                         appVersionId: appVersion.id,
                         createdByUserId: currentUserId,
-                        channelName: publishChannel,
+                        channelName: channel,
                         minDhisVersion,
                         maxDhisVersion,
                     },
@@ -179,7 +180,7 @@ module.exports = {
             } catch (err) {
                 await transaction.rollback()
                 throw Boom.internal(
-                    `Could not publish appversion to channel ${publishChannel}`,
+                    `Could not publish appversion to channel ${channel}`,
                     err
                 )
             }


### PR DESCRIPTION
Previously the appstore frontend had a static config for release channels, now they are being loaded dynamically from the backend instead. This PR also contains a few bug fixes regarding channels when editing/creating versions and uploading new apps.