### PR TITLE
feat: add possibility to delete an app version

### DIFF
--- a/client/src/components/appVersion/VersionListEdit.jsx
+++ b/client/src/components/appVersion/VersionListEdit.jsx
@@ -28,15 +28,25 @@ import { loadChannels } from '../../actions/actionCreators'
 
 const styles = {
     tableHeaderColumn: {
-        paddingLeft: '24px',
-        paddingRight: '24px',
+        paddingLeft: '12px',
+        paddingRight: '12px',
     },
     columnText: {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
     },
-    editColumn: {},
-    firstColumn: {},
+    editColumn: {
+        paddingLeft: '12px',
+        paddingRight: '12px',
+    },
+    firstColumn: {
+        paddingLeft: '12px',
+        paddingRight: '12px',
+    },
+    tableRowColumn: {
+        paddingLeft: '12px',
+        paddingRight: '12px',
+    },
     iconButton: {
         padding: '8px',
         width: '36px',
@@ -208,7 +218,7 @@ class VersionListEdit extends Component {
                         <TableIcon>file_download</TableIcon>
                     </a>
                 </TableRowColumn>
-                <TableRowColumn>
+                <TableRowColumn style={styles.tableRowColumn}>
                     {edit ? (
                         <TextField
                             defaultValue={version.demoUrl}
@@ -231,7 +241,7 @@ class VersionListEdit extends Component {
                         'N/A'
                     )}
                 </TableRowColumn>
-                <TableRowColumn>
+                <TableRowColumn style={styles.tableRowColumn}>
                     {edit ? (
                         <TextField
                             defaultValue={values.version}
@@ -246,7 +256,7 @@ class VersionListEdit extends Component {
                         values.version
                     )}
                 </TableRowColumn>
-                <TableRowColumn>
+                <TableRowColumn style={styles.tableRowColumn}>
                     {edit ? (
                         <TextField
                             defaultValue={values.minDhisVersion}
@@ -261,7 +271,7 @@ class VersionListEdit extends Component {
                         values.minDhisVersion
                     )}
                 </TableRowColumn>
-                <TableRowColumn>
+                <TableRowColumn style={styles.tableRowColumn}>
                     {edit ? (
                         <TextField
                             defaultValue={values.maxDhisVersion}
@@ -276,7 +286,7 @@ class VersionListEdit extends Component {
                         values.maxDhisVersion
                     )}
                 </TableRowColumn>
-                <TableRowColumn>
+                <TableRowColumn style={styles.tableRowColumn}>
                     {edit && !this.props.channels.loading ? (
                         <SelectField
                             value={values.channel}
@@ -298,6 +308,7 @@ class VersionListEdit extends Component {
                     )}
                 </TableRowColumn>
                 <TableRowColumn
+                    style={styles.tableRowColumn}
                     title={new Date(version.created).toLocaleString()}
                 >
                     {new Date(version.created).toLocaleDateString()}

--- a/src/data/deleteAppVersion.js
+++ b/src/data/deleteAppVersion.js
@@ -1,0 +1,23 @@
+const debug = require('debug')('appstore:server:data:deleteAppVersion')
+/**
+ * Deletes an app version with the specified uuid
+ *
+ * @param {string} uuid UUID for the app version to delete
+ * @param {object} knex database connection
+ * @param {object} transaction database transaction
+ * @returns {Promise}
+ */
+const deleteAppVersion = async (uuid, knex, transaction) => {
+    try {
+        await knex('app_version')
+            .transacting(transaction)
+            .where('uuid', uuid)
+            .del()
+        debug('deleted app version', uuid)
+    } catch (err) {
+        debug(err)
+        throw new Error(`Could not delete app version '${uuid}'`)
+    }
+}
+
+module.exports = deleteAppVersion

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -24,4 +24,5 @@ module.exports = {
     updateApp: require('./updateApp'),
     updateAppVersion: require('./updateAppVersion'),
     updateImageMeta: require('./updateImageMeta'),
+    deleteAppVersion: require('./deleteAppVersion'),
 }

--- a/src/routes/v1/apps/handlers/deleteAppVersion.js
+++ b/src/routes/v1/apps/handlers/deleteAppVersion.js
@@ -1,0 +1,63 @@
+const Boom = require('@hapi/boom')
+
+const {
+    getCurrentAuthStrategy,
+    getCurrentUserFromRequest,
+    currentUserIsManager,
+} = require('../../../../security')
+
+const { getAppDeveloperId, deleteAppVersion } = require('../../../../data')
+
+const { deleteFile } = require('../../../../utils')
+
+module.exports = {
+    method: 'DELETE',
+    path: '/v1/apps/{appUuid}/versions/{versionUuid}',
+    config: {
+        auth: getCurrentAuthStrategy(),
+        tags: ['api', 'v1'],
+        plugins: {
+            //TODO: set correct payloadType for 'hapi-swagger'
+        },
+        response: {
+            status: {
+                //TODO: add response statuses
+            },
+        },
+    },
+    handler: async (request, h) => {
+        request.logger.info('In handler %s', request.path)
+
+        const db = h.context.db
+
+        const { appUuid, versionUuid } = request.params
+
+        const currentUser = await getCurrentUserFromRequest(request, db)
+        const appDeveloperId = await getAppDeveloperId(appUuid, db)
+
+        const isManager = currentUserIsManager(request)
+
+        if (isManager || appDeveloperId === currentUser.id) {
+            //can edit app
+            const transaction = await db.transaction()
+
+            try {
+                await deleteAppVersion(versionUuid, db, transaction)
+                await transaction.commit()
+                await deleteFile(`${appUuid}/${versionUuid}`, 'app.zip')
+            } catch (err) {
+                await transaction.rollback()
+                throw Boom.internal(err)
+            }
+        } else {
+            throw Boom.unauthorized()
+        }
+
+        //What the old v1 api responds with on this endpoint if all works out
+        return {
+            httpStatus: 'OK',
+            httpStatusCode: 200,
+            message: 'Appversion deleted',
+        }
+    },
+}

--- a/src/routes/v1/apps/index.js
+++ b/src/routes/v1/apps/index.js
@@ -14,4 +14,5 @@ module.exports = [
     require('./handlers/uploadImageToApp'),
     require('./handlers/deleteImage'),
     require('./handlers/createAppVersion'),
+    require('./handlers/deleteAppVersion'),
 ]


### PR DESCRIPTION
This PR adds functionality in the new backend to delete a specific app version

It also tweaks the padding of the version list table to make for example the trash-icon visible again instead of hidden due to overflow when editing the app

We might want to double check that relational data gets deleted in the db as well when removing a row in the app_version table

* fixes DHIS2-7846

TODO: tests