### PR TITLE
fix: add route prefix the correct way

### DIFF
--- a/src/plugins/apiRoutes.js
+++ b/src/plugins/apiRoutes.js
@@ -71,7 +71,6 @@ const apiRoutesPlugin = {
             }
         }
 
-        server.realm.modifiers.route.prefix = '/api'
         server.route(routes)
     },
 }

--- a/src/server/init-server.js
+++ b/src/server/init-server.js
@@ -84,6 +84,10 @@ exports.init = async (knex, config) => {
             knex,
             auth: config.auth,
         },
+    }, {
+        routes: {
+            prefix: '/api'
+        }
     })
 
     await server.start()


### PR DESCRIPTION
We should not change the server.realm object, as per the [documentation](https://hapi.dev/api/?v=18.4.0#-serverrealm): 
> The server.realm object should be considered read-only and must not be changed directly except for the plugins property which can be directly manipulated by each plugin, setting its properties inside plugins[name].