### PR TITLE
fix: keep filters in redux form state when navigating around

### DIFF
--- a/client/src/components/appCards/AppCards.jsx
+++ b/client/src/components/appCards/AppCards.jsx
@@ -171,6 +171,7 @@ class AppCards extends Component {
                                         renderAllToggle={false}
                                         form="appTypeFilter"
                                         filters={appTypeFilters}
+                                        destroyOnUnmount={false}
                                     />
                                 </div>
                                 <div style={{ padding: '10px' }}>
@@ -179,6 +180,7 @@ class AppCards extends Component {
                                         renderAllToggle={false}
                                         form="appChannelFilter"
                                         filters={channelFilters}
+                                        destroyOnUnmount={false}
                                     />
                                 </div>
                             </Popover>

--- a/client/src/components/utils/Filters.jsx
+++ b/client/src/components/utils/Filters.jsx
@@ -168,7 +168,7 @@ class Selectfilter extends Component {
             labelStyle,
             filters,
             onFilterChange,
-            ...props
+            destroyOnUnmount,
         } = this.props
         const toggles = filters.map(filter => (
             <Field
@@ -178,6 +178,11 @@ class Selectfilter extends Component {
                 label={filter.label}
                 style={elementStyle}
                 labelStyle={labelStyle}
+                destroyOnUnmount={
+                    typeof destroyOnUnmount !== 'undefined'
+                        ? destroyOnUnmount
+                        : true
+                }
             />
         ))
         return (
@@ -220,6 +225,7 @@ Selectfilter.propTypes = {
     ),
     //Renders a component which toggles all buttons in this group.
     renderAllToggle: PropTypes.bool,
+    destroyOnUnmount: PropTypes.bool,
 }
 Selectfilter.defaultProps = {
     form: 'filters',

--- a/client/src/reducers/formReducer.js
+++ b/client/src/reducers/formReducer.js
@@ -97,6 +97,10 @@ const form = formReducer.plugin({
     appChannelFilter: (state, action) => {
         switch (action.type) {
             case actions.CHANNELS_LOAD_SUCCESS: {
+                if (state && state.values) {
+                    //if we've got old selections in the channel filter, keep them and just return previous state
+                    return state
+                }
                 const channels = action.payload
                 const filterValues = channels.reduce((acc, c) => {
                     acc[c.name] = c.name === 'Stable'

--- a/client/src/utils/history.js
+++ b/client/src/utils/history.js
@@ -1,4 +1,4 @@
-import createBrowserHistory from 'history/createBrowserHistory'
+import { createBrowserHistory } from 'history'
 import config from '../../../config'
 
 export const history = (() =>


### PR DESCRIPTION
The changes in this PR makes the channel and appType filter to stick in the redux store form section which makes it possible for the user to change filters, click into an application detail, then back without having the filters being reset to only display Stable again